### PR TITLE
Use forked version of postcss-default-unit plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Styles with props!",
   "source": "src/index.tsx",
   "main": "dist/index.js",
@@ -56,7 +56,7 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.merge": "^4.6.2",
     "postcss": "^7.0.30",
-    "postcss-default-unit": "^1.0.0",
+    "postcss-default-unit": "github:brombal/postcss-default-unit#main",
     "postcss-discard-duplicates": "^4.0.2",
     "postcss-inline-media": "^1.3.0",
     "postcss-nested": "^4.2.1"


### PR DESCRIPTION
The existing postcss-default-unit PostCSS plugin appears to have been abandoned. Since it appeared to have some bugs that weren't being addressed, I forked it specifically for use with Stylix. The code has been cleaned up and some unnecessary dependencies removed (you can see all the changes here: https://github.com/brombal/postcss-default-unit/blob/main/ChangeLog.md).

This should primarly address an issue (#1) where some values were incorrectly receiving the default unit suffix (such as 'px') even when the value was clearly not a number (such as `value-123`).
